### PR TITLE
Fixing fatal errors

### DIFF
--- a/Doom_CooldownPulse.lua
+++ b/Doom_CooldownPulse.lua
@@ -363,7 +363,7 @@ function DCP:CreateOptionsFrame()
     spellnamecbt:SetPoint("LEFT",spellnametext,"RIGHT",6,0)
     spellnamecbt:SetChecked(DCP_Saved.showSpellName)
     spellnamecbt:SetScript("OnClick", function(self) 
-        local newState = (self:GetChecked() == 1) or nil
+        local newState = self:GetChecked()
         self:SetChecked(newState)
         DCP_Saved.showSpellName = newState
         RefreshLocals()
@@ -419,6 +419,6 @@ function DCP:CreateOptionsFrame()
         button:SetWidth(75)
         button:SetPoint("BOTTOM", optionsframe, "BOTTOM", ((i%2==0 and -1) or 1)*45, ceil(i/2)*15 + (ceil(i/2)-1)*15)
         button:SetText(v.text)
-        button:SetScript("OnClick", function(self) PlaySound("igMainMenuOption") v.func(self) end)
+        button:SetScript("OnClick", function(self) PlaySound(852) v.func(self) end)
     end
 end

--- a/Doom_CooldownPulse.toc
+++ b/Doom_CooldownPulse.toc
@@ -1,4 +1,4 @@
-## Interface: 70000
+## Interface: 70300
 ## Title: Doom_CooldownPulse
 ## Notes: Flash an ability's icon in the middle of the screen when it comes off cooldown.
 ## Author: Woffle of Dark Iron[US]


### PR DESCRIPTION
Making the addon work again by applying [these fixes](https://github.com/aduth/Doom_CooldownPulse/issues/3#issuecomment-327696702) suggested by @Genimal

Those problems were due to those API changes since last update to the addon:

- [GetChecked now uses actual booleans](https://wow.gamepedia.com/API_CheckButton_GetChecked)
- [PlaySound doesn't accept strings anymore](https://wow.gamepedia.com/API_PlaySound)