### PR TITLE
Enabled the sliders to obey steps when dragging. This behaviour is no…

### DIFF
--- a/Doom_CooldownPulse.lua
+++ b/Doom_CooldownPulse.lua
@@ -466,6 +466,7 @@ function DCP:CreateOptionsFrame()
         getglobal("DCP_OptionsFrameSlider"..i.."High"):SetText(v.max)
         slider:SetMinMaxValues(v.min,v.max)
         slider:SetValueStep(v.step)
+        slider:SetObeyStepOnDrag(true)
         slider:SetValue(DCP_Saved[v.value])
         slider:SetScript("OnValueChanged",function()
             local val=slider:GetValue() DCP_Saved[v.value]=val


### PR DESCRIPTION
… longer implicit as of patch 5.4.2 and now needs to be called explicitly.

https://wowpedia.fandom.com/wiki/API_Slider_SetObeyStepOnDrag